### PR TITLE
Align SDK with current API specification

### DIFF
--- a/src/Account.php
+++ b/src/Account.php
@@ -12,6 +12,8 @@ final readonly class Account
         public ?\DateTimeImmutable $disabledAt,
         public string $company,
         public string $name,
+        public string $firstName,
+        public ?string $lastName,
         public string $email,
         public ?string $apiKey,
         public ?string $timeZone,

--- a/src/Request/RegisterAccount.php
+++ b/src/Request/RegisterAccount.php
@@ -9,10 +9,12 @@ final readonly class RegisterAccount extends AbstractRequest
 
     public function __construct(
         public string $company,
-        public string $name,
+        public string $firstName,
+        public string $lastName,
         public string $email,
         public string $password,
         public string $timeZone,
+        public bool $agreement = true,
     )
     {
     }
@@ -31,16 +33,18 @@ final readonly class RegisterAccount extends AbstractRequest
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, string|bool>
      */
     public function toArray(): array
     {
         return [
             'company' => $this->company,
-            'name' => $this->name,
+            'firstName' => $this->firstName,
+            'lastName' => $this->lastName,
             'email' => $this->email,
             'password' => $this->password,
             'timeZone' => $this->timeZone,
+            'agreement' => $this->agreement,
         ];
     }
 


### PR DESCRIPTION
## Summary

- Update `RegisterAccount` request to accept `firstName` and `lastName` instead of `name`, matching the API's account registration endpoint
- Add `agreement` parameter with a default value of `true`
- Add `firstName` and `lastName` properties to the `Account` response model

**Note:** `CreateModel`, `CreateProject`, and `ReadTrial` are already correct on `main` — no changes needed for those.

## Test plan

- [x] Verified against `gmoo-sdk-suite` PHP examples (`linear`) using Docker `php:8.4-cli`
- [ ] Review that existing consumers of `RegisterAccount` are updated

Part of globalMOO/gmoo-confluence#13